### PR TITLE
Add exception to age destroy when maxAge is 0 or less

### DIFF
--- a/src/ParticleEmitter/Particle.lua
+++ b/src/ParticleEmitter/Particle.lua
@@ -15,7 +15,7 @@ end
 
 function Particle:Update(delta, onUpdate)
 	
-	if self.age >= self.maxAge and self.age > 0 then 
+	if self.age >= self.maxAge and self.maxAge > 0 then 
 		self:Destroy()
 		return;
 	end;

--- a/src/ParticleEmitter/Particle.lua
+++ b/src/ParticleEmitter/Particle.lua
@@ -15,7 +15,7 @@ end
 
 function Particle:Update(delta, onUpdate)
 	
-	if self.age >= self.maxAge then 
+	if self.age >= self.maxAge and self.age > 0 then 
 		self:Destroy()
 		return;
 	end;


### PR DESCRIPTION
Make it so that if maxAge is 0 or less, the particle will never be destroyed due to it's age.